### PR TITLE
Fix unused constant for API's base url

### DIFF
--- a/helpscout.js
+++ b/helpscout.js
@@ -215,7 +215,7 @@ let getNewAccessToken = function(appCreds) {
 
   return new Promise(function(resolve, reject) {
     request({
-      url: 'https://api.helpscout.net/v2/oauth2/token?' + authStr,
+      url: BASE_URL + 'oauth2/token?' + authStr,
       method: 'POST'
     }, function (err, res, body) {
       if (err || res.statusCode >= 400) {


### PR DESCRIPTION
#### Why?
This is a simple fix where a constant is not reused. This way we can avoid repetition.

#### How?
Simply replace the duplicate data with the constant.
